### PR TITLE
Convert extension to a filter

### DIFF
--- a/_extensions/roughnotation/_extension.yml
+++ b/_extensions/roughnotation/_extension.yml
@@ -2,5 +2,5 @@ title: RoughNotations
 author: Emil Hvitfeldt
 version: 1.0.0
 contributes:
-  shortcodes:
+  filters:
     - rough.lua

--- a/_extensions/roughnotation/rough.js
+++ b/_extensions/roughnotation/rough.js
@@ -1,8 +1,6 @@
-<script src="_extensions/emilhvitfeldt/roughnotation/assets/rough-notation.iife.js"></script>
-<script>
-var rn_counter = 0;
+document.addEventListener("DOMContentLoaded", function () {
+  var rn_counter = 0;
 
-document.addEventListener("DOMContentLoaded", function() {
   Reveal.on("slidechanged", (event) => {
     rn_counter = 0;
   });
@@ -17,7 +15,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
   Reveal.addKeyBinding(
     { keyCode: 82, key: "R", description: "Trigger RoughNotation" },
-    () => {
+    function () {
       rn_counter = rn_counter + 1;
 
       const slide = Reveal.getCurrentSlide();
@@ -57,4 +55,3 @@ document.addEventListener("DOMContentLoaded", function() {
     }
   );
 })
-</script>

--- a/_extensions/roughnotation/rough.lua
+++ b/_extensions/roughnotation/rough.lua
@@ -1,4 +1,4 @@
-function rn_setup()
+function Meta(m)
   quarto.doc.addHtmlDependency({
     name = "roughnotation",
     version = "1.0.0",

--- a/_extensions/roughnotation/rough.lua
+++ b/_extensions/roughnotation/rough.lua
@@ -2,7 +2,6 @@ function Meta(m)
   quarto.doc.addHtmlDependency({
     name = "roughnotation",
     version = "1.0.0",
-    scripts = {"assets/rough-notation.iife.js"}
+    scripts = {"assets/rough-notation.iife.js", "rough.js"}
   })
-  quarto.doc.includeFile("after-body", "assets/roughnotation.html")
 end

--- a/_extensions/roughnotation/rough.lua
+++ b/_extensions/roughnotation/rough.lua
@@ -1,7 +1,12 @@
 function Meta(m)
   quarto.doc.addHtmlDependency({
     name = "roughnotation",
+    version = "0.5.1",
+    scripts = {"assets/rough-notation.iife.js"}
+  })
+  quarto.doc.addHtmlDependency({
+    name = "roughnotation-init",
     version = "1.0.0",
-    scripts = {"assets/rough-notation.iife.js", "rough.js"}
+    scripts = {"rough.js"}
   })
 end

--- a/example.qmd
+++ b/example.qmd
@@ -1,11 +1,11 @@
 ---
 title: "Untitled"
 format: revealjs
+filters:
+  - roughnotation
 ---
 
 ## Quarto
-
-{{< rn_setup >}}
 
 [weave together]{.rn rn-color="red" rn-type="box" rn-index=1 rn-animationDuration=2000}
 


### PR DESCRIPTION
Turns the extension into a filter rather than a shortcode. I also moved the initialization script into a JavaScript file (so it's easier to edit). Lastly, I made sure that the dependency added to the quarto doc for `roughnotation` is very clear that it's providing version 0.5.1.