### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/roughnotation/_schema.yml
+++ b/_extensions/roughnotation/_schema.yml
@@ -1,0 +1,52 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+attributes:
+  rn-fragment:
+    rn-type:
+      type: string
+      enum:
+        - underline
+        - box
+        - circle
+        - highlight
+        - strike-through
+        - crossed-off
+        - bracket
+      description: Rough notation annotation style.
+    rn-color:
+      type: string
+      description: Annotation stroke or highlight colour.
+      completion:
+        type: color
+    rn-animate:
+      type: boolean
+      description: Animate drawing of the annotation.
+    rn-animationDuration:
+      type: integer
+      min: 0
+      description: Animation duration in milliseconds.
+    rn-strokeWidth:
+      type: number
+      min: 0
+      description: Annotation line thickness.
+    rn-padding:
+      type: number
+      min: 0
+      description: Padding around annotated content.
+    rn-multiline:
+      type: boolean
+      description: Allow annotation across multiple lines.
+    rn-iterations:
+      type: integer
+      min: 1
+      description: Number of rough drawing iterations.
+    rn-brackets:
+      type: string
+      description: Bracket sides when rn-type is bracket (for example left,right).
+    rn-rtl:
+      type: boolean
+      description: Draw annotations right-to-left.
+
+classes:
+  rn-fragment:
+    description: Reveal.js fragment annotated by roughnotation.

--- a/_extensions/roughnotation/_snippets.json
+++ b/_extensions/roughnotation/_snippets.json
@@ -1,0 +1,18 @@
+{
+  "Roughnotation span": {
+    "prefix": "rn-span",
+    "body": [
+      "[${1:highlighted text}]{.rn-fragment rn-type=${2:underline} rn-color=${3:red}}"
+    ],
+    "description": "Insert an inline roughnotation fragment."
+  },
+  "Roughnotation div": {
+    "prefix": "rn-div",
+    "body": [
+      "::: {.rn-fragment rn-type=${1:box} rn-color=${2:orange}}",
+      "${3:Annotated block content}",
+      ":::"
+    ],
+    "description": "Insert a block roughnotation fragment."
+  }
+}


### PR DESCRIPTION
This PR improves Quarto Wizard support (VS Code/Positron) for this extension by adding extension metadata files used for editor assistance.

### What this adds
- `_schema.yml` with extension-specific fields (options/classes/attributes and/or format keys) to enable better completion, hover docs, and validation.
- `_snippets.json` with practical insertion snippets for common extension usage.

### Why
These files improve authoring UX in Quarto projects by making extension configuration and usage easier to discover and less error-prone in VSCode/Positron when using Quarto Wizard.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html